### PR TITLE
space instead of hyphen and space in between Mata and Nui

### DIFF
--- a/BMOPEn.po
+++ b/BMOPEn.po
@@ -703,8 +703,8 @@ msgstr "Gali’s Landing"
 #. SourceLocation:	/Game/BluePrints/Classes/LevelingSystem/Locations/LocationEntry_GaTemple.Default__LocationEntry_GaTemple_C.Location Name
 #: /Game/BluePrints/Classes/LevelingSystem/Locations/LocationEntry_GaTemple.Default__LocationEntry_GaTemple_C.Location Name
 msgctxt "CodexPage_Name,CodexPage_GaTemple"
-msgid "Temple of MataNui"
-msgstr "Temple of Mata-Nui"
+msgid "Temple of Mata Nui"
+msgstr "Temple of Mata Nui"
 
 #. Key:	CodexPage_GaWahi
 #. SourceLocation:	/Game/BluePrints/Classes/LevelingSystem/Locations/LocationEntry_GaWahi.Default__LocationEntry_GaWahi_C.Location Name


### PR DESCRIPTION
There shouldn't be a hyphen in Mata Nui, a space instead. I don't know any instances when someone types MataNui or Mata-Nui instead of Mata Nui. That's how it's written on all the wikis, books and comics. It's already Mata Nui in all the cases above in this file as can remember.